### PR TITLE
fix query keyword argument name "str" to "keyword"

### DIFF
--- a/searcher.py.c
+++ b/searcher.py.c
@@ -48,7 +48,7 @@ PyObject *do_search(PyObject *self, PyObject *args, PyObject* kwargs)
 			return NULL;
 		}
 
-		PyObject *py_kw = PyDict_GetItemString(item, "str");
+		PyObject *py_kw = PyDict_GetItemString(item, "keyword");
 		PyObject *py_type = PyDict_GetItemString(item, "type");
 		PyObject *py_field = PyDict_GetItemString(item, "field");
 		PyObject *py_boost = PyDict_GetItemString(item, "boost");


### PR DESCRIPTION
An error occurs for searching a formula with pya0 even I just copy and pasted a cell in the demo notebook file.
It is caused by the inconsistency between pya0 demo notebook and pya0-0.3.5.
So I replaced the key "str" to "keyword" in searcher.py.c to resolve the problem.